### PR TITLE
feat: complete Axolotlik Cosmo Cats lab 2 (feature toggles & aop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,17 @@ src/
 ├── main/
 │ ├── java/org/axolotlik/axolotlikcosmocats/
 │ │ ├── common/                             # Загальні утиліти, enum-и
-│ │ ├── config/                             # Конфігурації Spring / Swagger
+│ │ ├── config/                             # Конфігурації Spring / Swagger / FeatureToggleProperties
 │ │ ├── domain/                             # Доменні моделі (Product, Category, Order, Cart)
 │ │ ├── dto/                                # DTO для вхідних і вихідних даних
+│ │ ├── featuretoggle/                      # Реалізація Feature Toggles (AOP + конфігурація)
+│ │ │   ├── annotation/                     # Анотації для фіч
+│ │ │   ├── aspect/                         # Аспект для перевірки стану фіч перед виконанням
+│ │ │   ├── exception/                      # Кастомний ексцепш для виключених фіч
+│ │ │   ├── service/                        # Сервіс керування фічами
+│ │ │   └── FeatureToggles.java             # Enum зі списком доступних фіч
+│ │ ├── config/                             # Конфігурації Spring / Swagger / FeatureToggleProperties
+│ │ ├── web/                                # REST контролери (в т.ч. CosmoCatsController)
 │ │ ├── repository/                         # In-Memory репозиторії для зберігання даних у колекціях
 │ │ ├── service/                            # Бізнес-логіка (CRUD, валідації)
 │ │ ├── util/                               # Кастомні валідації, хелпери
@@ -44,6 +52,7 @@ src/
 │   └── api-specs/                          # Swagger / OpenAPI контракт
 │
 └── test/java/org/axolotlik/axolotlikcosmocats/
+    ├── featuretoggle/                      # Тестові анотації та розширення JUnit для FeatureToggle
     ├── repository/                         # Unit-тести для InMemoryRepository
     ├── service/impl/                       # Unit-тести для сервісного шару
     └── web/                                # Integration-тести для контролерів
@@ -145,11 +154,11 @@ src/
 ```
 Test Coverage:
     - Class Coverage: 100%
-    - Method Coverage: 95.3%
-    - Branch Coverage: 66.7%
-    - Line Coverage: 94.2%
-    - Instruction Coverage: 95.1%
-    - Complexity Coverage: 79.6%
+    - Method Coverage: 95.9%
+    - Branch Coverage: 67.6%
+    - Line Coverage: 94.8%
+    - Instruction Coverage: 95.6%
+    - Complexity Coverage: 81.8%
 ``` 
 
 **TestCoverage**
@@ -158,10 +167,10 @@ Test Coverage:
 Test Coverage:
     - Class Coverage: 100%
     - Method Coverage: 100%
-    - Branch Coverage: 69.4%
-    - Line Coverage: 96%
-    - Instruction Coverage: 97.5%
-    - Complexity Coverage: 84.5%
+    - Branch Coverage: 70.3%
+    - Line Coverage: 96.4%
+    - Instruction Coverage: 97.8%
+    - Complexity Coverage: 86.2%
 ```
 
 ---
@@ -177,6 +186,55 @@ Test Coverage:
 ```
 build/reports/coverage/index.html
 ```
+
+---
+
+## 🚀 Лабораторна 1.3 — Feature Toggles (Spring AOP)
+
+### 🎯 Мета
+
+Реалізувати систему **Feature Toggle** для керування функціональністю застосунку залежно від середовища (environment).
+
+---
+
+### ⚙️ Реалізація
+
+* Додано **`FeatureToggleService`** для зберігання та керування станом фіч.
+* Налаштовано **`FeatureToggleProperties`**, що читає YAML-конфігурацію (`application.feature.*`).
+* Створено **аспект `FeatureToggleAspect`**, який:
+
+    * перевіряє активність фіч перед виконанням методу;
+    * кидає `FeatureNotAvailableException`, якщо фіча вимкнена;
+    * інтегрований через Spring AOP (`@Aspect`).
+
+---
+
+### 🐱 Новий функціонал
+
+* Створено **CosmoCatsController** з ендпоінтами:
+
+    * `GET /api/v1/cosmo-cats` — отримати всіх котиків (працює лише якщо фіча активна);
+    * `GET /api/v1/cosmo-cats/{name}` — отримати конкретного котика;
+* Додано виняток **FeatureNotAvailableException** з кодом **503 Service Unavailable**;
+* Розширено **GlobalExceptionHandler** для обробки цієї помилки.
+
+---
+
+### 🤪 Тестування (Feature Toggle)
+
+* Створено розширення **`FeatureToggleExtension`** для JUnit 5, яке:
+
+    * автоматично вмикає / вимикає фічу перед кожним тестом;
+    * повертає конфігурацію до початкового стану після тесту.
+* Додано кастомні анотації:
+
+    * `@EnabledFeatureToggle`
+    * `@DisabledFeatureToggle`
+* Написано **інтеграційні тести для CosmoCatsController**:
+
+    * ✅ `200 OK` — коли фіча активна;
+    * 🚫 `503 Service Unavailable` — коли фіча вимкнена;
+    * ⚠️ `404 Not Found` — коли кота не знайдено;
 
 ## ✨ Автор
 

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ build/reports/coverage/index.html
 
 * Створено **CosmoCatsController** з ендпоінтами:
 
-    * `GET /api/v1/cosmo-cats` — отримати всіх котиків (працює лише якщо фіча активна);
-    * `GET /api/v1/cosmo-cats/{name}` — отримати конкретного котика;
+    * `GET /api/v1/galactic-citizen-registry` — отримати всіх котиків (працює лише якщо фіча активна);
+    * `GET /api/v1/galactic-citizen-registry/{name}` — отримати конкретного котика;
 * Додано виняток **FeatureNotAvailableException** з кодом **503 Service Unavailable**;
 * Розширено **GlobalExceptionHandler** для обробки цієї помилки.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ build/reports/coverage/index.html
 
 ---
 
-## 🚀 Лабораторна 1.3 — Feature Toggles (Spring AOP)
+## 🚀 Лабораторна 2 — Feature Toggles (Spring AOP)
 
 ### 🎯 Мета
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,8 @@ ext {
     minimumCoveragePerFile = 0.8
     filesExcludedFromCoverage = [
             "**/*Application.*",
-            "**/config/*Configuration.*"
+            "**/config/*Config*",
+            "**/config/*Properties.*"
     ]
 }
 
@@ -40,6 +41,7 @@ apply from: "${rootProject.projectDir}/gradle/jacoco.gradle"
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.4'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'jakarta.validation:jakarta.validation-api:3.1.0'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/AxolotlikCosmoCatsApplication.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/AxolotlikCosmoCatsApplication.java
@@ -2,8 +2,10 @@ package org.axolotlik.axolotlikcosmocats;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @SpringBootApplication
+@EnableAspectJAutoProxy
 public class AxolotlikCosmoCatsApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/config/FeatureToggleProperties.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/config/FeatureToggleProperties.java
@@ -1,0 +1,19 @@
+package org.axolotlik.axolotlikcosmocats.config;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@Configuration
+@ConfigurationProperties(prefix = "application")
+public class FeatureToggleProperties {
+
+  private Map<String, Boolean> feature = new HashMap<>();
+
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/FeatureToggles.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/FeatureToggles.java
@@ -1,0 +1,15 @@
+package org.axolotlik.axolotlikcosmocats.featuretoggle;
+
+import lombok.Getter;
+
+@Getter
+public enum FeatureToggles {
+  COSMO_CATS("cosmo-cats"),
+  KITTY_PRODUCTS("kitty-products");
+
+  private final String featureName;
+
+  FeatureToggles(String featureName) {
+    this.featureName = featureName;
+  }
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/FeatureToggles.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/FeatureToggles.java
@@ -4,8 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum FeatureToggles {
-  COSMO_CATS("cosmo-cats"),
-  KITTY_PRODUCTS("kitty-products");
+  //змінив імена фіч, однак використання таке ж саме
+  GALACTIC_CITIZEN_REGISTRY("galactic-citizen-registry"),
+  DEEP_SPACE_MARKETPLACE("deep-space-marketplace");
 
   private final String featureName;
 

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/annotation/FeatureToggle.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/annotation/FeatureToggle.java
@@ -1,0 +1,12 @@
+package org.axolotlik.axolotlikcosmocats.featuretoggle.annotation;
+
+
+import org.axolotlik.axolotlikcosmocats.featuretoggle.FeatureToggles;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FeatureToggle {
+  FeatureToggles value();
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/aspect/FeatureToggleAspect.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/aspect/FeatureToggleAspect.java
@@ -1,0 +1,25 @@
+package org.axolotlik.axolotlikcosmocats.featuretoggle.aspect;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.annotation.FeatureToggle;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.exception.FeatureNotAvailableException;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.service.FeatureToggleService;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class FeatureToggleAspect {
+
+  private final FeatureToggleService featureToggleService;
+
+  @Before("@annotation(featureToggle)")
+  public void checkFeatureEnabled(FeatureToggle featureToggle) {
+    String featureName = featureToggle.value().getFeatureName();
+    if (!featureToggleService.check(featureName)) {
+      throw new FeatureNotAvailableException(featureName);
+    }
+  }
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/exception/FeatureNotAvailableException.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/exception/FeatureNotAvailableException.java
@@ -1,0 +1,9 @@
+package org.axolotlik.axolotlikcosmocats.featuretoggle.exception;
+
+public class FeatureNotAvailableException extends RuntimeException {
+  public static final String FEATURE_NOT_AVAILABLE = "Feature %s is not available right now.";
+
+  public FeatureNotAvailableException(String featureName) {
+    super(String.format(FEATURE_NOT_AVAILABLE, featureName));
+  }
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/service/FeatureToggleService.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/service/FeatureToggleService.java
@@ -7,7 +7,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class FeatureToggleService {
-
+  // ConcurrentHashMap гарантує thread-safety при одночасному читанні/записі.
+  // Це критично, бо сервіс працює в багатопотоковому середовищі,
+  // і зміна стану фічі в рантаймі не повинна ламати запити інших користувачів.
   private final ConcurrentHashMap<String, Boolean> featureToggles;
 
   public FeatureToggleService(FeatureToggleProperties featureToggleProperties) {

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/service/FeatureToggleService.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/featuretoggle/service/FeatureToggleService.java
@@ -1,0 +1,28 @@
+package org.axolotlik.axolotlikcosmocats.featuretoggle.service;
+
+import org.axolotlik.axolotlikcosmocats.config.FeatureToggleProperties;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class FeatureToggleService {
+
+  private final ConcurrentHashMap<String, Boolean> featureToggles;
+
+  public FeatureToggleService(FeatureToggleProperties featureToggleProperties) {
+    this.featureToggles = new ConcurrentHashMap<>(featureToggleProperties.getFeature());
+  }
+
+  public boolean check(String featureName) {
+    return featureToggles.getOrDefault(featureName, false);
+  }
+
+  public void enable(String featureName) {
+    featureToggles.put(featureName, true);
+  }
+
+  public void disable(String featureName) {
+    featureToggles.put(featureName, false);
+  }
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/service/CosmoCatService.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/service/CosmoCatService.java
@@ -1,0 +1,10 @@
+package org.axolotlik.axolotlikcosmocats.service;
+
+import java.util.List;
+
+public interface CosmoCatService {
+
+  List<String> getCosmoCats();
+
+  String getCosmoCatByName(String name);
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/service/exception/CatNotFoundException.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/service/exception/CatNotFoundException.java
@@ -1,0 +1,7 @@
+package org.axolotlik.axolotlikcosmocats.service.exception;
+
+public class CatNotFoundException extends NotFoundException {
+  public CatNotFoundException(String name) {
+    super("Cat", name);
+  }
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/service/exception/NotFoundException.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/service/exception/NotFoundException.java
@@ -2,9 +2,14 @@ package org.axolotlik.axolotlikcosmocats.service.exception;
 
 public abstract class NotFoundException extends RuntimeException {
   public static final String ID_NOT_FOUND = "%s with id %s not found";
+  public static final String NAME_NOT_FOUND = "%s with name %s not found";
 
   public NotFoundException(String objectType, Long id) {
     super(String.format(ID_NOT_FOUND, objectType, id));
+  }
+
+  public NotFoundException(String objectType, String name) {
+    super(String.format(NAME_NOT_FOUND, objectType, name));
   }
 
   public NotFoundException(String message) {

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/service/impl/CosmoCatServiceImpl.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/service/impl/CosmoCatServiceImpl.java
@@ -1,0 +1,26 @@
+package org.axolotlik.axolotlikcosmocats.service.impl;
+
+import org.axolotlik.axolotlikcosmocats.service.CosmoCatService;
+import org.axolotlik.axolotlikcosmocats.service.exception.CatNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CosmoCatServiceImpl implements CosmoCatService {
+
+  private final List<String> cosmoCats = List.of("Luna", "Comet", "Nebula", "Orion");
+
+  @Override
+  public List<String> getCosmoCats() {
+    return cosmoCats;
+  }
+
+  @Override
+  public String getCosmoCatByName(String name) {
+    return cosmoCats.stream()
+        .filter(cat -> cat.equalsIgnoreCase(name))
+        .findFirst()
+        .orElseThrow(() -> new CatNotFoundException(name));
+  }
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/web/CosmoCatController.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/web/CosmoCatController.java
@@ -10,19 +10,19 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/cosmo-cats")
+@RequestMapping("/api/v1/galactic-citizen-registry")
 @RequiredArgsConstructor
 public class CosmoCatController {
 
   private final CosmoCatService cosmoCatService;
 
-  @FeatureToggle(FeatureToggles.COSMO_CATS)
+  @FeatureToggle(FeatureToggles.GALACTIC_CITIZEN_REGISTRY)
   @GetMapping
   public ResponseEntity<List<String>> getCosmoCats() {
     return ResponseEntity.ok(cosmoCatService.getCosmoCats());
   }
 
-  @FeatureToggle(FeatureToggles.COSMO_CATS)
+  @FeatureToggle(FeatureToggles.GALACTIC_CITIZEN_REGISTRY)
   @GetMapping("/{name}")
   public ResponseEntity<String> getCosmoCat(@PathVariable String name) {
     return ResponseEntity.ok(cosmoCatService.getCosmoCatByName(name));

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/web/CosmoCatController.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/web/CosmoCatController.java
@@ -1,0 +1,30 @@
+package org.axolotlik.axolotlikcosmocats.web;
+
+import org.axolotlik.axolotlikcosmocats.featuretoggle.FeatureToggles;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.annotation.FeatureToggle;
+import org.axolotlik.axolotlikcosmocats.service.CosmoCatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/cosmo-cats")
+@RequiredArgsConstructor
+public class CosmoCatController {
+
+  private final CosmoCatService cosmoCatService;
+
+  @FeatureToggle(FeatureToggles.COSMO_CATS)
+  @GetMapping
+  public ResponseEntity<List<String>> getCosmoCats() {
+    return ResponseEntity.ok(cosmoCatService.getCosmoCats());
+  }
+
+  @FeatureToggle(FeatureToggles.COSMO_CATS)
+  @GetMapping("/{name}")
+  public ResponseEntity<String> getCosmoCat(@PathVariable String name) {
+    return ResponseEntity.ok(cosmoCatService.getCosmoCatByName(name));
+  }
+}

--- a/src/main/java/org/axolotlik/axolotlikcosmocats/web/GlobalExceptionHandler.java
+++ b/src/main/java/org/axolotlik/axolotlikcosmocats/web/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package org.axolotlik.axolotlikcosmocats.web;
 
-import jakarta.validation.ConstraintViolationException;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.exception.FeatureNotAvailableException;
 import org.axolotlik.axolotlikcosmocats.service.exception.NotFoundException;
 import org.axolotlik.axolotlikcosmocats.web.exception.ValidationError;
 import org.springframework.http.HttpHeaders;
@@ -27,6 +27,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     ProblemDetail detail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
     detail.setTitle("Resource Not Found");
     detail.setType(URI.create("not-found"));
+    return detail;
+  }
+
+  // 503 - feature disabled
+  @ExceptionHandler(FeatureNotAvailableException.class)
+  ProblemDetail handleFeatureNotAvailable(FeatureNotAvailableException ex) {
+    ProblemDetail detail =
+        ProblemDetail.forStatusAndDetail(HttpStatus.SERVICE_UNAVAILABLE, ex.getMessage());
+    detail.setTitle("Feature Unavailable");
+    detail.setType(URI.create("feature-unavailable"));
     return detail;
   }
 

--- a/src/main/resources/api-specs/market-api-spec.yml
+++ b/src/main/resources/api-specs/market-api-spec.yml
@@ -477,6 +477,69 @@ paths:
         '204':
           description: Cart deleted successfully (idempotent).
 
+    # ==============================
+  # 🐱 COSMO CATS
+  # ==============================
+  /api/v1/cosmo-cats:
+    get:
+      summary: Get all Cosmo Cats
+      description: >
+        Returns a list of Cosmo Cat names.  
+        This endpoint is controlled by the `cosmo-cats.enabled` feature toggle.
+      tags: [ Cosmo Cats ]
+      responses:
+        '200':
+          description: Successfully retrieved list of Cosmo Cats.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                example: [ "Luna", "Comet", "Nebula", "Orion" ]
+        '503':
+          description: Feature not available (when toggle is disabled).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseDto'
+
+  /api/v1/cosmo-cats/{name}:
+    get:
+      summary: Get Cosmo Cat by name
+      description: >
+        Returns the name of a specific Cosmo Cat if it exists.  
+        Controlled by the same feature toggle (`cosmo-cats.enabled`).
+      tags: [ Cosmo Cats ]
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Name of the Cosmo Cat.
+      responses:
+        '200':
+          description: Successfully retrieved the Cosmo Cat name.
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Luna"
+        '404':
+          description: Cosmo Cat not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseDto'
+        '503':
+          description: Feature not available (when toggle is disabled).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseDto'
+
+
 components:
   schemas:
     # 🛒 PRODUCTS
@@ -663,36 +726,64 @@ components:
           example: [ 1 ]
           description: List of product IDs to remove from the cart.
 
-
     # ⚠️ ERRORS
-    ValidationErrorDto:
-      type: object
-      properties:
-        status:
-          type: integer
-          example: 400
-        error:
-          type: string
-          example: "Bad Request"
-        message:
-          type: string
-          example: "Field 'price' must be greater than 0."
-        path:
-          type: string
-          example: "/api/v1/products"
-
     ErrorResponseDto:
       type: object
       properties:
+        type:
+          type: string
+          example: "feature-unavailable"
+          description: "Machine-readable error type"
+        title:
+          type: string
+          example: "Feature Unavailable"
+          description: "Short human-readable summary of the error"
         status:
           type: integer
-          example: 404
-        error:
+          example: 503
+          description: "HTTP status code"
+        detail:
           type: string
-          example: "Not Found"
-        message:
+          example: "Feature 'cosmo-cats.enabled' is not available right now."
+          description: "Detailed human-readable explanation"
+        instance:
           type: string
-          example: "Category with ID 15 not found."
-        path:
+          example: "/api/v1/cosmo-cats"
+          description: "Request path where the error occurred"
+
+    ValidationErrorDto:
+      type: object
+      properties:
+        type:
+          type: string
+          example: "validation-error"
+          description: "Machine-readable identifier of the validation error"
+        title:
+          type: string
+          example: "Validation Failed"
+          description: "Human-readable summary of the validation failure"
+        status:
+          type: integer
+          example: 400
+          description: "HTTP status code"
+        instance:
           type: string
           example: "/api/v1/products"
+          description: "The request path where the error occurred"
+        errors:
+          type: array
+          description: "List of validation field errors"
+          items:
+            $ref: '#/components/schemas/ValidationFieldError'
+
+    ValidationFieldError:
+      type: object
+      properties:
+        field:
+          type: string
+          example: "price"
+          description: "The field that failed validation"
+        reason:
+          type: string
+          example: "must be greater than or equal to 0.01"
+          description: "Human-readable explanation of the validation issue"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,8 +14,8 @@ springdoc:
 
 application:
   feature:
-    cosmo-cats: true
-    kitty-products: false
+    galactic-citizen-registry: true
+    deep-space-marketplace: false
 
 ---
 spring:
@@ -24,4 +24,4 @@ spring:
       on-profile: dev
 application:
   feature:
-    cosmo-cats: false
+    galactic-citizen-registry: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
-spring.application.name: AxolotlikCosmoCats
+spring:
+  profiles:
+    active: local
+  application:
+    name: AxolotlikCosmoCats
 
 springdoc:
   swagger-ui:
@@ -8,3 +12,16 @@ springdoc:
   api-docs:
     enabled: true
 
+application:
+  feature:
+    cosmo-cats: true
+    kitty-products: false
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+application:
+  feature:
+    cosmo-cats: false

--- a/src/test/java/org/axolotlik/axolotlikcosmocats/featuretoggle/FeatureToggleExtension.java
+++ b/src/test/java/org/axolotlik/axolotlikcosmocats/featuretoggle/FeatureToggleExtension.java
@@ -1,0 +1,67 @@
+package org.axolotlik.axolotlikcosmocats.featuretoggle;
+
+import org.axolotlik.axolotlikcosmocats.featuretoggle.annotation.DisabledFeatureToggle;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.annotation.EnabledFeatureToggle;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.service.FeatureToggleService;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class FeatureToggleExtension implements BeforeEachCallback, AfterEachCallback {
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    context
+        .getTestMethod()
+        .ifPresent(
+            method -> {
+              FeatureToggleService service = getFeatureToggleService(context);
+
+              if (method.isAnnotationPresent(EnabledFeatureToggle.class)) {
+                var annotation = method.getAnnotation(EnabledFeatureToggle.class);
+                service.enable(annotation.value().getFeatureName());
+              } else if (method.isAnnotationPresent(DisabledFeatureToggle.class)) {
+                var annotation = method.getAnnotation(DisabledFeatureToggle.class);
+                service.disable(annotation.value().getFeatureName());
+              }
+            });
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    context
+        .getTestMethod()
+        .ifPresent(
+            method -> {
+              String featureName = null;
+              if (method.isAnnotationPresent(EnabledFeatureToggle.class)) {
+                featureName =
+                    method.getAnnotation(EnabledFeatureToggle.class).value().getFeatureName();
+              } else if (method.isAnnotationPresent(DisabledFeatureToggle.class)) {
+                featureName =
+                    method.getAnnotation(DisabledFeatureToggle.class).value().getFeatureName();
+              }
+
+              if (featureName != null) {
+                FeatureToggleService service = getFeatureToggleService(context);
+                boolean originalState = getFeaturePropertyFromYaml(context, featureName);
+                if (originalState) {
+                  service.enable(featureName);
+                } else {
+                  service.disable(featureName);
+                }
+              }
+            });
+  }
+
+  private boolean getFeaturePropertyFromYaml(ExtensionContext context, String featureName) {
+    Environment env = SpringExtension.getApplicationContext(context).getEnvironment();
+    return env.getProperty("application.feature." + featureName, Boolean.class, Boolean.FALSE);
+  }
+
+  private FeatureToggleService getFeatureToggleService(ExtensionContext context) {
+    return SpringExtension.getApplicationContext(context).getBean(FeatureToggleService.class);
+  }
+}

--- a/src/test/java/org/axolotlik/axolotlikcosmocats/featuretoggle/annotation/DisabledFeatureToggle.java
+++ b/src/test/java/org/axolotlik/axolotlikcosmocats/featuretoggle/annotation/DisabledFeatureToggle.java
@@ -1,0 +1,14 @@
+package org.axolotlik.axolotlikcosmocats.featuretoggle.annotation;
+
+import org.axolotlik.axolotlikcosmocats.featuretoggle.FeatureToggles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface DisabledFeatureToggle {
+    FeatureToggles value();
+}

--- a/src/test/java/org/axolotlik/axolotlikcosmocats/featuretoggle/annotation/EnabledFeatureToggle.java
+++ b/src/test/java/org/axolotlik/axolotlikcosmocats/featuretoggle/annotation/EnabledFeatureToggle.java
@@ -1,0 +1,14 @@
+package org.axolotlik.axolotlikcosmocats.featuretoggle.annotation;
+
+import org.axolotlik.axolotlikcosmocats.featuretoggle.FeatureToggles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface EnabledFeatureToggle {
+  FeatureToggles value();
+}

--- a/src/test/java/org/axolotlik/axolotlikcosmocats/web/CosmoCatControllerIT.java
+++ b/src/test/java/org/axolotlik/axolotlikcosmocats/web/CosmoCatControllerIT.java
@@ -30,18 +30,18 @@ class CosmoCatControllerIT {
   @Test
   @SneakyThrows
   @DisplayName("should return 200 OK when feature is enabled (GET all cats)")
-  @EnabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  @EnabledFeatureToggle(FeatureToggles.GALACTIC_CITIZEN_REGISTRY)
   void shouldReturn200WhenFeatureEnabled() {
-    mockMvc.perform(get("/api/v1/cosmo-cats")).andExpect(status().isOk());
+    mockMvc.perform(get("/api/v1/galactic-citizen-registry")).andExpect(status().isOk());
   }
 
   @Test
   @SneakyThrows
   @DisplayName("should return 503 with proper error body when feature is disabled (GET all cats)")
-  @DisabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  @DisabledFeatureToggle(FeatureToggles.GALACTIC_CITIZEN_REGISTRY)
   void shouldReturn503WhenFeatureDisabled() {
     mockMvc
-        .perform(get("/api/v1/cosmo-cats"))
+        .perform(get("/api/v1/galactic-citizen-registry"))
         .andExpect(status().isServiceUnavailable())
         .andExpect(jsonPath("$.status").value(503))
         .andExpect(jsonPath("$.title").value("Feature Unavailable"))
@@ -49,26 +49,26 @@ class CosmoCatControllerIT {
             jsonPath("$.detail")
                 .value(
                     String.format(
-                        FeatureNotAvailableException.FEATURE_NOT_AVAILABLE, "cosmo-cats")))
-        .andExpect(jsonPath("$.instance").value("/api/v1/cosmo-cats"));
+                        FeatureNotAvailableException.FEATURE_NOT_AVAILABLE, "galactic-citizen-registry")))
+        .andExpect(jsonPath("$.instance").value("/api/v1/galactic-citizen-registry"));
   }
 
   @Test
   @SneakyThrows
   @DisplayName("should return 200 OK when getting specific cat and feature is enabled")
-  @EnabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  @EnabledFeatureToggle(FeatureToggles.GALACTIC_CITIZEN_REGISTRY)
   void shouldReturn200WhenGettingSpecificCatFeatureEnabled() {
-    mockMvc.perform(get("/api/v1/cosmo-cats/{name}", "Luna")).andExpect(status().isOk());
+    mockMvc.perform(get("/api/v1/galactic-citizen-registry/{name}", "Luna")).andExpect(status().isOk());
   }
 
   @Test
   @SneakyThrows
   @DisplayName(
       "should return 503 with proper error body when getting specific cat and feature is disabled")
-  @DisabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  @DisabledFeatureToggle(FeatureToggles.GALACTIC_CITIZEN_REGISTRY)
   void shouldReturn503WhenGettingSpecificCatFeatureDisabled() {
     mockMvc
-        .perform(get("/api/v1/cosmo-cats/{name}", "Luna"))
+        .perform(get("/api/v1/galactic-citizen-registry/{name}", "Luna"))
         .andExpect(status().isServiceUnavailable())
         .andExpect(jsonPath("$.status").value(503))
         .andExpect(jsonPath("$.title").value("Feature Unavailable"))
@@ -76,23 +76,23 @@ class CosmoCatControllerIT {
             jsonPath("$.detail")
                 .value(
                     String.format(
-                        FeatureNotAvailableException.FEATURE_NOT_AVAILABLE, "cosmo-cats")))
-        .andExpect(jsonPath("$.instance").value("/api/v1/cosmo-cats/Luna"));
+                        FeatureNotAvailableException.FEATURE_NOT_AVAILABLE, "galactic-citizen-registry")))
+        .andExpect(jsonPath("$.instance").value("/api/v1/galactic-citizen-registry/Luna"));
   }
 
   @Test
   @SneakyThrows
   @DisplayName("should return 404 with proper error body when cat not found and feature is enabled")
-  @EnabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  @EnabledFeatureToggle(FeatureToggles.GALACTIC_CITIZEN_REGISTRY)
   void shouldReturn404WhenCatNotFoundAndFeatureEnabled() {
     mockMvc
-        .perform(get("/api/v1/cosmo-cats/{name}", "Unknown"))
+        .perform(get("/api/v1/galactic-citizen-registry/{name}", "Unknown"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.status").value(404))
         .andExpect(jsonPath("$.title").value("Resource Not Found"))
         .andExpect(
             jsonPath("$.detail")
                 .value(String.format(CatNotFoundException.NAME_NOT_FOUND, "Cat", "Unknown")))
-        .andExpect(jsonPath("$.instance").value("/api/v1/cosmo-cats/Unknown"));
+        .andExpect(jsonPath("$.instance").value("/api/v1/galactic-citizen-registry/Unknown"));
   }
 }

--- a/src/test/java/org/axolotlik/axolotlikcosmocats/web/CosmoCatControllerIT.java
+++ b/src/test/java/org/axolotlik/axolotlikcosmocats/web/CosmoCatControllerIT.java
@@ -1,0 +1,98 @@
+package org.axolotlik.axolotlikcosmocats.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import lombok.SneakyThrows;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.FeatureToggleExtension;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.FeatureToggles;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.annotation.DisabledFeatureToggle;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.annotation.EnabledFeatureToggle;
+import org.axolotlik.axolotlikcosmocats.featuretoggle.exception.FeatureNotAvailableException;
+import org.axolotlik.axolotlikcosmocats.service.exception.CatNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("Integration tests for CosmoCatsController")
+@ExtendWith(FeatureToggleExtension.class)
+class CosmoCatControllerIT {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  @SneakyThrows
+  @DisplayName("should return 200 OK when feature is enabled (GET all cats)")
+  @EnabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  void shouldReturn200WhenFeatureEnabled() {
+    mockMvc.perform(get("/api/v1/cosmo-cats")).andExpect(status().isOk());
+  }
+
+  @Test
+  @SneakyThrows
+  @DisplayName("should return 503 with proper error body when feature is disabled (GET all cats)")
+  @DisabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  void shouldReturn503WhenFeatureDisabled() {
+    mockMvc
+        .perform(get("/api/v1/cosmo-cats"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.status").value(503))
+        .andExpect(jsonPath("$.title").value("Feature Unavailable"))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    String.format(
+                        FeatureNotAvailableException.FEATURE_NOT_AVAILABLE, "cosmo-cats")))
+        .andExpect(jsonPath("$.instance").value("/api/v1/cosmo-cats"));
+  }
+
+  @Test
+  @SneakyThrows
+  @DisplayName("should return 200 OK when getting specific cat and feature is enabled")
+  @EnabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  void shouldReturn200WhenGettingSpecificCatFeatureEnabled() {
+    mockMvc.perform(get("/api/v1/cosmo-cats/{name}", "Luna")).andExpect(status().isOk());
+  }
+
+  @Test
+  @SneakyThrows
+  @DisplayName(
+      "should return 503 with proper error body when getting specific cat and feature is disabled")
+  @DisabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  void shouldReturn503WhenGettingSpecificCatFeatureDisabled() {
+    mockMvc
+        .perform(get("/api/v1/cosmo-cats/{name}", "Luna"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.status").value(503))
+        .andExpect(jsonPath("$.title").value("Feature Unavailable"))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(
+                    String.format(
+                        FeatureNotAvailableException.FEATURE_NOT_AVAILABLE, "cosmo-cats")))
+        .andExpect(jsonPath("$.instance").value("/api/v1/cosmo-cats/Luna"));
+  }
+
+  @Test
+  @SneakyThrows
+  @DisplayName("should return 404 with proper error body when cat not found and feature is enabled")
+  @EnabledFeatureToggle(FeatureToggles.COSMO_CATS)
+  void shouldReturn404WhenCatNotFoundAndFeatureEnabled() {
+    mockMvc
+        .perform(get("/api/v1/cosmo-cats/{name}", "Unknown"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.status").value(404))
+        .andExpect(jsonPath("$.title").value("Resource Not Found"))
+        .andExpect(
+            jsonPath("$.detail")
+                .value(String.format(CatNotFoundException.NAME_NOT_FOUND, "Cat", "Unknown")))
+        .andExpect(jsonPath("$.instance").value("/api/v1/cosmo-cats/Unknown"));
+  }
+}


### PR DESCRIPTION
# 🌌 Axolotlik Cosmo Cats — Lab 2 (Feature Toggles & AOP)

## 🧠 Опис
Додано механізм **динамічного вмикання та вимикання фіч** за допомогою **Spring AOP**, розширено конфігурацію, додано інтеграційні тести та оновлено `README.md`.

---

## ⚙️ Що зроблено

### 🧩 **Feature Toggle механізм**
- Реалізовано `FeatureToggleService` — зберігає й керує станом фіч.  
- Додано `FeatureToggleAspect` — перевіряє стан фіч перед виконанням методів.  
- Додано `FeatureToggles` enum — централізований перелік усіх фіч.  
- Створено власну помилку `FeatureNotAvailableException` → повертає **503 Service Unavailable**.  
- Додано YAML-конфігурацію з можливістю зміни стану фіч через профілі (`local`, `dev`).  

---

### 🧪 **Інтеграційні тести**
- Створено **FeatureToggleExtension** — керує фічами під час тестування.  
- Додано кастомні анотації:
  - `@EnabledFeatureToggle`
  - `@DisabledFeatureToggle`
- Додано тести для `CosmoCatController`:
  - ✅ `200 OK` — коли фіча активна  
  - 🚫 `503 Service Unavailable` — коли фіча вимкнена  
  - ⚠️ `404 Not Found` — коли кота не знайдено  

---

### 🧱 **Оновлення структури**
- Додано новий модуль: `featuretoggle/`
  - `FeatureToggleService`
  - `FeatureToggleAspect`
  - `FeatureToggleExtension`
  - `@EnabledFeatureToggle`, `@DisabledFeatureToggle`
- Розширено `GlobalExceptionHandler` для обробки нових типів помилок.  
- Оновлено `application.yml` з підтримкою профілів середовища.  
- Оновлено `README.md` з новою секцією лабораторної 2.  

---

## 🧾 Результат
✅ Система фіч-тоглів повністю інтегрована.  
⚙️ Тепер можна **вмикати або вимикати функціональність** без зміни коду — лише через YAML або тестові анотації.  
📈 Проєкт готовий до подальших розширень і нових лабораторних завдань.
